### PR TITLE
Fix TypeError in Android

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-animated-checkbox",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Minimalistic, animated and customizable <CheckBox /> component for React Native.",
   "main": "src/index.js",
   "types": "src/index.d.ts",

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ import {
 import Icon from 'react-native-vector-icons/FontAwesome';
 /* eslint-enable */
 
-const styles = StyleSheet.create({
+const styles = {
   iconContainer: {
     alignItems: 'center',
     justifyContent: 'center',
@@ -23,7 +23,7 @@ const styles = StyleSheet.create({
     borderRadius: 0,
     borderWidth: 2,
   },
-});
+};
 
 export default class Checkbox extends PureComponent {
   static propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,6 @@ import {
   TouchableOpacity,
   View,
   ViewPropTypes,
-  StyleSheet,
 } from 'react-native';
 /* eslint-disable import/no-extraneous-dependencies, import/no-unresolved */
 import Icon from 'react-native-vector-icons/FontAwesome';


### PR DESCRIPTION
This fixed the issue #1 

We can't just access the style created by StyleSheet.create(). If we want to access it, we have to flatten the StyleSheet object, or simply just don't use StyleSheet.create().

I used the second option.